### PR TITLE
Create shodan_API.py

### DIFF
--- a/ReconnaissanceTools/shodan_API.py
+++ b/ReconnaissanceTools/shodan_API.py
@@ -1,0 +1,33 @@
+import os
+import shodan
+import sys
+
+# API Key needs to be added to the Environment Variable prior to use.
+api_key = os.environ['SHODAN_API_KEY']
+api = shodan.Shodan(api_key)
+
+# Takes the first argument (IP Address)provided when calling the script.
+ip_address = sys.argv[1]
+
+# Implement a TRY/CATCH to catch any errors that may occur.
+try:
+    host = api.host(ip_address)
+
+    print("-------------------------------------------------------------------------")
+    print("Organisation:", host['org'])
+    print("IP Address:", host['ip_str'])
+    print("Country Name:", host['country_name'])
+    print("Domains:", host['domains'])
+    print("Host Name:", host['hostnames'])
+    print("Operating System:", host.get('os','n/a'))
+    print("-------------------------------------------------------------------------")
+    for item in host ['data']:
+        print("""
+        * Product: {}
+        * Port: {}
+        * Transport: {}""".format(item.get('product'),item['port'],item['transport']))
+
+    print("\nLast Shodan Scan:", host['last_update'])
+
+except Exception as e:
+    print('Error: {}'.format(e))


### PR DESCRIPTION
Passive Recon of a target using Shodan API integration. From a penetration testers' perspective, passive should always be the first go-to.
An example use case, list all open ports for a specified IP.
There is a lot of information you can capture through this API and for the most part, it's passive.

Note: Shodan does a scan approx once per week.

Link: https://www.shodan.io/
Documentation: https://shodan.readthedocs.io/en/latest/
Official Python library and CLI for Shodan: https://github.com/achillean/shodan-python

![image](https://user-images.githubusercontent.com/61313910/160611584-9b32bc41-3011-4545-bbca-d502f1366894.png)
