### PR TITLE
fix: add shodan dep to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyglet == 1.5.22
 scapy == 2.4.5
 tqdm == 4.63.0
 pylint == 2.12.2
+shodan == 1.27.0


### PR DESCRIPTION
Users cannot open the application without first installing `shodan` as a requirement, this simply adds it to the `requirements.txt` so the initial setup covers this dep too.